### PR TITLE
feat: 事例詳細ページに事例IDを表示

### DIFF
--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -86,7 +86,10 @@ export default function DetailPage() {
         </Link>
       </div>
 
-      <h1 className="text-2xl font-bold mb-4">{caseData.title}</h1>
+      <div className="mb-4">
+        <p className="text-sm text-gray-500 mb-1">{caseData.id}</p>
+        <h1 className="text-2xl font-bold">{caseData.title}</h1>
+      </div>
 
       {caseData.ethical_notes && caseData.ethical_notes.length > 0 && (
         <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">


### PR DESCRIPTION
## Summary
- 事例詳細ページのタイトル上部に事例ID（例: `priv-0001`）を表示するようにした
- URLを確認しなくても事例IDが一目で分かるようになる

Closes #27

## Test plan
- [ ] 事例詳細ページを開き、タイトルの上にグレーの小さい文字で事例IDが表示されることを確認
- [ ] 複数の事例ページで正しいIDが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)