### PR TITLE
fix: Header・Footerの表示名を正式名称に統一

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,7 +2,7 @@ export default function Footer() {
   return (
     <footer className="border-t border-gray-200 bg-white py-4">
       <div className="max-w-7xl mx-auto px-4 text-center text-sm text-gray-500 space-y-1">
-        <p>&copy; {new Date().getFullYear()} プライバシー事例カタログ</p>
+        <p>&copy; {new Date().getFullYear()} データ活用・プライバシー炎上事例カタログ</p>
         <p>
           ソースコード・データは{' '}
           <a

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,7 +8,7 @@ export default function Header() {
     <header className="bg-white shadow-sm border-b border-gray-200">
       <div className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
         <Link to="/" className="text-lg font-bold text-gray-900 hover:text-blue-700">
-          プライバシー事例カタログ
+          データ活用・プライバシー炎上事例カタログ
         </Link>
 
         {/* Desktop nav */}


### PR DESCRIPTION
## Summary
- Header.tsx・Footer.tsx の「プライバシー事例カタログ」を「データ活用・プライバシー炎上事例カタログ」に変更
- index.html・AboutPage と表示名を統一

Closes #29

## Test plan
- [ ] ヘッダーのサイト名が「データ活用・プライバシー炎上事例カタログ」と表示されること
- [ ] フッターのコピーライト表記が「データ活用・プライバシー炎上事例カタログ」と表示されること
- [ ] TypeScript型チェック通過済み（`tsc --noEmit` OK）
- [ ] テスト・ビルドは環境の `@tailwindcss/oxide` ネイティブバインディング問題で実行不可（変更内容はJSX文字列のみのため影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)