### PR TITLE
fix: 一覧ページから組織名表示を除外

### DIFF
--- a/src/pages/ListPage.tsx
+++ b/src/pages/ListPage.tsx
@@ -38,7 +38,6 @@ function CaseTable({ cases }: { cases: Case[] }) {
         <thead>
           <tr className="border-b-2 border-gray-200 bg-gray-50 text-left">
             <th className="py-2.5 px-3 font-medium text-gray-600 whitespace-nowrap">タイトル</th>
-            <th className="py-2.5 px-3 font-medium text-gray-600 whitespace-nowrap">組織</th>
             <th className="py-2.5 px-3 font-medium text-gray-600 whitespace-nowrap">カテゴリ</th>
             <th className="py-2.5 px-3 font-medium text-gray-600 whitespace-nowrap">深刻度</th>
             <th className="py-2.5 px-3 font-medium text-gray-600 whitespace-nowrap">地域</th>
@@ -55,7 +54,6 @@ function CaseTable({ cases }: { cases: Case[] }) {
                   {c.title}
                 </Link>
               </td>
-              <td className="py-2.5 px-3 text-gray-600 whitespace-nowrap">{c.organization}</td>
               <td className="py-2.5 px-3">
                 <div className="flex flex-wrap gap-1">
                   {c.incident_category.map((cat) => (
@@ -205,7 +203,6 @@ export default function ListPage() {
                   <ReviewStatusBadge status={c.review_status} />
                 </div>
                 <h2 className="text-base font-semibold mb-2 pr-20 line-clamp-2">{c.title}</h2>
-                <p className="text-sm text-gray-600 mb-2">{c.organization}</p>
 
                 <div className="flex flex-wrap gap-1.5 mb-2">
                   <SeverityBadge severity={c.severity} />


### PR DESCRIPTION
## Summary
- 事例一覧ページ（カード表示・テーブル表示）から組織名（organization）の表示を除外
- 長い組織名による一覧の視認性低下を解消
- 事例詳細ページでは引き続き組織名を表示

Closes #28

## Test plan
- [x] `npm run test` 全テストパス
- [x] `npm run build` ビルド成功
- [ ] カード表示で組織名が非表示であることを確認
- [ ] テーブル表示で組織名カラムが除外されていることを確認
- [ ] 詳細ページで組織名が引き続き表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)