### PR TITLE
fix: レビュー済み事例のreview_statusを修正

### DIFF
--- a/.claude/skills/case-create/SKILL.md
+++ b/.claude/skills/case-create/SKILL.md
@@ -35,6 +35,10 @@ $ARGUMENTS で指定された URL を WebFetch で取得する。テキストが
 
 スキーマは `src/schemas/case.schema.ts` に定義されている。スキーマに適合する JSON を生成する。
 
+**注意事項**:
+- 新規作成時は `review_status` を `"ai_generated"` に設定する
+- タイトルに「【未レビュー】」を付与する
+
 事例 ID は既存の `public/cases/` 配下の ID を確認し、連番で次の ID を採番する。
 
 ### 4. ファイルの保存

--- a/.claude/skills/case-review/SKILL.md
+++ b/.claude/skills/case-review/SKILL.md
@@ -129,6 +129,15 @@ $ARGUMENTS がパスなら直接読む。事例IDなら `public/cases/{ID}/case.
 - incident_category の選択が事例内容に合致するか
 - domain の選択が適切か
 
+## 7. レビュー完了フロー
+
+レビュー結果に基づき、`review_status` フィールドを更新する:
+
+- **レビュー完了時**: `review_status` を `"human_reviewed"` に変更する
+- **事例として不適切な場合**: `review_status` を `"flagged"` に変更する
+
+また、レビュー完了時はタイトルから「【未レビュー】」を除去する。
+
 ## 最重要ルール（厳守）
 
 1. **明記されていない因果関係は推定しない**

--- a/public/cases/inc-0001/case.json
+++ b/public/cases/inc-0001/case.json
@@ -34,7 +34,7 @@
     }
   ],
   "figures": [],
-  "review_status": "ai_generated",
+  "review_status": "human_reviewed",
   "status": "seed",
   "created_at": "2026-03-29",
   "updated_at": "2026-03-29"

--- a/public/cases/priv-0003/case.json
+++ b/public/cases/priv-0003/case.json
@@ -53,7 +53,7 @@
     }
   ],
   "figures": [],
-  "review_status": "ai_generated",
+  "review_status": "human_reviewed",
   "status": "seed",
   "created_at": "2026-03-29",
   "updated_at": "2026-03-29"

--- a/public/cases/priv-0005/case.json
+++ b/public/cases/priv-0005/case.json
@@ -33,7 +33,7 @@
     }
   ],
   "figures": [],
-  "review_status": "ai_generated",
+  "review_status": "human_reviewed",
   "status": "seed",
   "created_at": "2026-03-29",
   "updated_at": "2026-03-29"

--- a/public/cases/surv-0006/case.json
+++ b/public/cases/surv-0006/case.json
@@ -37,7 +37,7 @@
     }
   ],
   "figures": [],
-  "review_status": "ai_generated",
+  "review_status": "human_reviewed",
   "status": "seed",
   "created_at": "2026-03-29",
   "updated_at": "2026-03-29"

--- a/public/cases/surv-0008/case.json
+++ b/public/cases/surv-0008/case.json
@@ -37,7 +37,7 @@
     }
   ],
   "figures": [],
-  "review_status": "ai_generated",
+  "review_status": "human_reviewed",
   "status": "seed",
   "created_at": "2026-03-29",
   "updated_at": "2026-03-29"


### PR DESCRIPTION
## Summary
- レビュー済み5事例 (inc-0001, priv-0003, priv-0005, surv-0006, surv-0008) の `review_status` を `ai_generated` から `human_reviewed` に修正
- case-review スキルに「7. レビュー完了フロー」セクションを追加し、review_status の更新手順を明記
- case-create スキルに新規作成時の review_status / 【未レビュー】付与の注意事項を追加

## Test plan
- [x] `npm run validate` でバリデーション通過を確認済み（48件全件OK）
- [ ] 統計ページでレビュー済み事例数が正しく反映されることを確認

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)