### PR TITLE
develop → main: 事例追加(anon-0005, algo-0005)を本番反映

### DIFF
--- a/public/cases/algo-0005/case.json
+++ b/public/cases/algo-0005/case.json
@@ -1,0 +1,77 @@
+{
+  "id": "algo-0005",
+  "title": "【未レビュー】子どもの顔画像から自閉症を判定するAI研究、無断収集データセットで大量論文撤回",
+  "region": "国外",
+  "domain": "医療",
+  "domain_sub": "AI研究・学術出版",
+  "organization": "学術出版社（Springer Nature、PLOS、Elsevier、IEEE 等）",
+  "incident_category": [
+    "algorithmic_discrimination",
+    "privacy_violation",
+    "unauthorized_use"
+  ],
+  "severity": "high",
+  "occurred_at": "2025",
+  "summary": "顔画像から自閉スペクトラム症（ASD）を判定する深層学習研究が、子どもの顔画像を無断収集したデータセットに依拠していたとして、2025年に多数の論文が撤回された。問題のデータセットは、退職したエンジニアが2019年に自閉症関連のウェブサイトから子どもの写真をダウンロードして作成し、Kaggleで公開したもので、写っている子どものASD診断は検証されておらず、保護者が画像の公開・研究利用に同意したかも不明とされる。各出版社は、データセットの倫理面と妥当性への懸念から、これを用いた論文の信頼性を維持できないと判断した。",
+  "impact": "Springer Nature社は合計約38件の論文・会議録・書籍章を撤回対象として特定し、IEEEは当該Kaggleデータセットを用いた25件の論文に懸念表明（expression of concern）を付した。ElsevierやPLOSも該当論文を撤回した。PLOS Oneでは関連論文が2025年12月23日にサイトから削除され、うち1件は同年12月16日に子どもの顔写真を除去する形で再公開された後に削除された。顔の外見的特徴から自閉症を判定するという科学的妥当性そのものに加え、同意を得ずに収集した子どもの顔画像を医療AI研究に利用することの倫理的問題が広く議論された。",
+  "root_cause": "研究に用いられたKaggleの「自閉症児顔画像データセット」は、自閉症関連サイトから無断でダウンロードされた子どもの写真で構成されており、写っている子どものASD診断は臨床的に検証されていなかった。画像ごとに照明や角度が異なり、顔の特徴差を識別する科学的根拠としても疑わしいものであった。研究者・査読者・出版社が、データセットの出所・同意・診断の妥当性を十分に確認しないまま、「分野の標準的慣行」と考えて利用・公表したことが背景にあるとされる。顔の外見から神経発達特性を推定するという発想自体が、骨相学的な偏見を再生産するリスクをはらむ。",
+  "response": "懸念が表面化した後、Springer Natureは約38件を撤回対象として特定し、IEEEは25件に懸念表明を付した。ElsevierおよびPLOSも該当論文を撤回した。PLOS Oneは2025年12月、複数の関連論文を撤回・削除し、子どもの顔写真を含む版を差し替える対応を取った。著者の一部は、Kaggleデータセットの利用は分野の標準的慣行と考えた善意の判断であったと説明したと報じられている。",
+  "lessons_learned": "公開データセットであっても、出所・同意・対象者の診断の妥当性を確認せずに利用してはならない。特に未成年者の顔画像のような機微なデータは、保護者の同意と倫理審査を欠いた利用が重大な権利侵害となる。顔の外見的特徴から自閉症などの神経発達特性を判定するというタスクは、科学的妥当性が乏しいだけでなく、外見に基づく差別や偏見（骨相学的バイアス）を再生産する危険がある。研究者・査読者・出版社の各段階で、データセットの来歴（データ・プロビナンス）と倫理的正当性を検証する仕組みが求められる。",
+  "tags": [
+    "自閉症",
+    "顔画像",
+    "医療AI",
+    "アルゴリズム差別",
+    "子どもの個人情報",
+    "同意なきデータ利用",
+    "論文撤回",
+    "データセット倫理",
+    "Kaggle",
+    "骨相学バイアス"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Exclusive: Springer Nature retracts, removes nearly 40 publications that trained neural networks on 'bonkers' dataset - The Transmitter",
+      "url": "https://www.thetransmitter.org/retraction/exclusive-springer-nature-retracts-removes-nearly-40-publications-that-trained-neural-networks-on-bonkers-dataset/"
+    },
+    {
+      "source_type": "web",
+      "title": "Retraction: A deep learning-based ensemble for autism spectrum disorder diagnosis using facial images - PLOS One",
+      "url": "https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0340328"
+    },
+    {
+      "source_type": "web",
+      "title": "Why dozens of autism publications were retracted - Medical Brief",
+      "url": "https://www.medicalbrief.co.za/why-dozens-of-autism-publications-were-retracted/"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "無断収集データセットによる自閉症判定AI研究のデータフロー",
+      "data": {
+        "nodes": [
+          { "id": "source", "label": "自閉症関連サイトから無断収集された子どもの顔画像（2019年作成のKaggleデータセット）", "category": "source" },
+          { "id": "trigger", "label": "顔画像から自閉症を判定する深層学習研究に利用・多数の論文として公表", "category": "trigger" },
+          { "id": "incident", "label": "診断未検証・保護者の同意不明・科学的妥当性への懸念が指摘", "category": "incident" },
+          { "id": "impact", "label": "Springer Nature約38件を撤回、IEEE25件に懸念表明、PLOS・Elsevierも撤回", "category": "impact" },
+          { "id": "response", "label": "各出版社が論文の撤回・削除・差し替えを実施、データ倫理を議論", "category": "response" }
+        ],
+        "edges": [
+          { "from": "source", "to": "trigger", "label": "学習データとして利用" },
+          { "from": "trigger", "to": "incident", "label": "倫理・妥当性の問題発覚" },
+          { "from": "incident", "to": "impact", "label": "信頼性喪失" },
+          { "from": "impact", "to": "response", "label": "出版社の対応" }
+        ]
+      },
+      "note": "公開データセットでも来歴・同意・診断の妥当性の検証を欠くと、機微な子どもの顔画像が同意なく研究に流用される。顔の外見からの自閉症判定は科学的妥当性にも乏しい。"
+    }
+  ],
+  "review_status": "ai_generated",
+  "status": "seed",
+  "ethical_notes": [
+    "本事例は学術出版社の撤回通知および公開報道に基づいて記述しています。被害を受けた子どもの特定情報は含みません。",
+    "顔の外見的特徴から自閉症を判定するという主張には科学的妥当性への重大な疑義があり、本カタログはこうした手法を支持するものではありません。"
+  ]
+}

--- a/public/cases/anon-0005/case.json
+++ b/public/cases/anon-0005/case.json
@@ -1,0 +1,81 @@
+{
+  "id": "anon-0005",
+  "title": "【未レビュー】CNIL、IQVIAの健康データを「匿名」ではなく「仮名化された個人データ」と判断し500万ユーロ制裁",
+  "region": "国外",
+  "country": "フランス",
+  "domain": "医療",
+  "domain_sub": "ヘルスデータ・ウェアハウス",
+  "organization": "IQVIA OPERATIONS FRANCE",
+  "incident_category": [
+    "inadequate_anonymization",
+    "privacy_violation"
+  ],
+  "severity": "high",
+  "occurred_at": "2026-05",
+  "summary": "2026年5月26日、フランスのデータ保護当局CNILは、IQVIA OPERATIONS FRANCEに対し500万ユーロの制裁金を科す決定（SAN-2026-008）を行い、5月28日に公表した。IQVIAはCNILの承認を受けた2つの健康データウェアハウス（約14,000の薬局から収集したLRX、複数千名の医師から収集したEMR）を運用していた。IQVIAはこれらのデータを「匿名データ」でありGDPR等の規制対象外と主張したが、CNILは患者ごとの一意識別子の存在、データの粒度の高さ、保有データと公開情報の突合可能性などから、合理的手段による再識別が可能であり、匿名データではなく仮名化された個人データに該当すると判断した。",
+  "impact": "IQVIAに対し500万ユーロの制裁金が科され、加えて6か月以内の是正命令と、遅延1日あたり1万ユーロの追加制裁金が課された。本決定は同一のアーキテクチャを共有する102の事業者にも影響を及ぼすと報じられた。健康データのように粒度が高く履歴性・一意識別子・外部データとの突合可能性があるデータについて、直接識別子の削除やハッシュ化・仮名化だけでは匿名化とは評価されないことが、当局の正式決定として明確に示された。",
+  "root_cause": "IQVIAは直接識別子を外した健康データを「匿名データ」と位置づけ、データ保護規制の対象外として扱っていたが、CNILは再識別リスクが消去されていないと判断した。具体的には、患者ごとの一意識別子が存在すること、年齢・性別・処方・診断・症状・身長体重・検査・ワクチン・病欠等とデータの粒度が高いこと、同一患者の診療・処方履歴を追跡できること、IQVIAが保有するデータと公開情報を組み合わせることで合理的手段による再識別が可能であることが指摘された。情報提供、権利行使、データセキュリティ等に関する保証措置の遵守も不十分とされた。",
+  "response": "CNILは2026年5月26日付の決定SAN-2026-008で500万ユーロの制裁金を決定し、6か月以内の是正命令（遅延1日あたり1万ユーロの制裁金付き）を課した。正式決定文では、匿名化判断の観点として individualisation（個人の切り出し）、corrélation（レコード間の関連付け）、inférence（属性推論）のリスクが参照されている。決定は2026年5月28日に公表された。",
+  "lessons_learned": "直接識別子を削除しハッシュ化や仮名化を行っていても、それだけでは匿名化とは評価されない。特に健康データのように粒度が高く、履歴性・一意識別子・外部データとの突合可能性がある場合、匿名化の成立は厳しく評価される。「匿名加工済み」「匿名データ」と説明する場合は、singling out（個人の切り出し）、linkability（連結可能性）、inference（属性推論）、合理的手段による再識別可能性まで含めたリスク評価が必要である。データが仮名化された個人データに該当する場合は、情報提供、権利行使、目的・根拠、セキュリティ、利用範囲等の規制対応が引き続き求められる。",
+  "tags": [
+    "匿名化不備",
+    "仮名化",
+    "再識別",
+    "健康データ",
+    "GDPR",
+    "CNIL",
+    "IQVIA",
+    "データウェアハウス",
+    "制裁金"
+  ],
+  "sources": [
+    {
+      "source_type": "web",
+      "title": "Health data: fine of 5 million euros against IQVIA | CNIL",
+      "url": "https://www.cnil.fr/en/health-data-fine-5-million-euros-against-iqvia"
+    },
+    {
+      "source_type": "web",
+      "title": "Délibération SAN-2026-008 du 26 mai 2026 concernant la société IQVIA OPERATIONS FRANCE - Légifrance",
+      "url": "https://www.legifrance.gouv.fr/cnil/id/CNILTEXT000054136834"
+    },
+    {
+      "source_type": "web",
+      "title": "The CNIL Fines IQVIA €5 Million: Pseudonymization Remains GDPR for Key Holders - ActuIA",
+      "url": "https://www.actuia.com/en/news/the-cnil-fines-iqvia-eur5-million-pseudonymization-remains-gdpr-for-key-holders/"
+    }
+  ],
+  "figures": [
+    {
+      "type": "data_flow",
+      "title": "健康データの匿名化判断をめぐるデータフロー",
+      "data": {
+        "nodes": [
+          { "id": "source", "label": "約14,000の薬局・複数千名の医師から処方・診療データを収集（LRX/EMR）", "category": "source" },
+          { "id": "trigger", "label": "IQVIAが直接識別子を外し「匿名データ」として規制対象外と主張", "category": "trigger" },
+          { "id": "incident", "label": "CNILが一意識別子・高い粒度・公開情報との突合可能性から仮名化された個人データと判断", "category": "incident" },
+          { "id": "impact", "label": "500万ユーロの制裁金、同一構造の102事業者に影響", "category": "impact" },
+          { "id": "response", "label": "6か月以内の是正命令（遅延1日あたり1万ユーロ）", "category": "response" }
+        ],
+        "edges": [
+          { "from": "source", "to": "trigger", "label": "ウェアハウスで蓄積" },
+          { "from": "trigger", "to": "incident", "label": "当局による評価" },
+          { "from": "incident", "to": "impact", "label": "制裁決定" },
+          { "from": "impact", "to": "response", "label": "是正命令" }
+        ]
+      },
+      "note": "CNILは individualisation・corrélation・inférence の観点から再識別リスクを評価し、匿名データではなく仮名化された個人データと結論づけた。"
+    }
+  ],
+  "review_status": "ai_generated",
+  "status": "seed",
+  "related_laws": ["GDPR", "フランス・データ保護法"],
+  "penalty_amount": {
+    "amount": 5000000,
+    "currency": "EUR",
+    "authority": "CNIL（フランス国家情報処理・自由委員会）"
+  },
+  "ethical_notes": [
+    "本事例はCNILの公式発表および公開報道に基づいて記述しています。被害を受けた個人の特定情報は含みません。"
+  ]
+}


### PR DESCRIPTION
## 概要

`develop` を `main` に反映し、GitHub Pages に公開します。

## 含まれる変更

- 事例追加 `anon-0005`（issue #83）: CNILがIQVIAの健康データを「匿名」ではなく仮名化された個人データと判断し500万ユーロ制裁
- 事例追加 `algo-0005`（issue #82）: 子どもの顔画像から自閉症を判定するAI研究が無断収集データセットで大量論文撤回

## 検証

- `npm run validate` 成功（50件）
- PR #84 のCI（validate-and-test）成功済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBz8eSHDeMHKsGFPwySLsR)_